### PR TITLE
Add automatic package discovery and change Alert to use Interfaces

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,10 +11,7 @@
 	],
 	"require": {
 		"php": ">=5.6.0",
-		"illuminate/session": "^5.0",
-		"illuminate/support": "^5.0",
-		"illuminate/config": "^5.0",
-		"illuminate/view": "^5.0"
+		"illuminate/support": "^5.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "~4.0",

--- a/composer.json
+++ b/composer.json
@@ -25,5 +25,15 @@
 			"HieuLe\\Alert\\": "src/"
 		}
 	},
-	"minimum-stability": "stable"
+	"minimum-stability": "stable",
+	"extra": {
+		"laravel": {
+			"providers": [
+				"HieuLe\\Alert\\AlertServiceProvider"
+			],
+			"aliases": {
+				"Alert": "HieuLe\\Alert\\Facades\\Alert"
+			}
+		}
+	}
 }

--- a/src/Alert.php
+++ b/src/Alert.php
@@ -3,9 +3,9 @@
 namespace HieuLe\Alert;
 
 use \Illuminate\Support\MessageBag;
-use \Illuminate\Session\Store;
-use \Illuminate\Config\Repository;
-use \Illuminate\View\Factory;
+use \Illuminate\Contracts\Session\Session;
+use \Illuminate\Contracts\Config\Repository;
+use \Illuminate\Contracts\View\Factory;
 
 /**
  * The global site message system for Laravel
@@ -18,7 +18,7 @@ class Alert extends MessageBag
     /**
      * Laravel session
      *
-     * @var type 
+     * @var Session
      */
     protected $session;
 
@@ -36,7 +36,7 @@ class Alert extends MessageBag
      */
     protected $view;
 
-    public function __construct(Store $session, Repository $config, Factory $view, array $messages = array())
+    public function __construct(Session $session, Repository $config, Factory $view, array $messages = array())
     {
         $this->session = $session;
         $this->config  = $config;


### PR DESCRIPTION
Changed composer.json so that laravel >= 5.5 automaticly detects the package.
Changed the Alert class to use Interfaces in stead of the presumed class. This also reduced the amount of dependencies.